### PR TITLE
fix: use value field for TXT DNS record creation

### DIFF
--- a/src/pycdmon/cli.py
+++ b/src/pycdmon/cli.py
@@ -132,7 +132,7 @@ def main(argv: list[str] | None = None) -> int:
                     "host": args.host,
                     "type": args.type_,
                     "ttl": args.ttl,
-                    "destination": args.destination,
+                    "value" if args.type_.upper() == "TXT" else "destination": args.destination,
                 }
                 if args.priority is not None:
                     record["priority"] = args.priority

--- a/src/pycdmon/client.py
+++ b/src/pycdmon/client.py
@@ -142,7 +142,10 @@ class CdmonDomainsClient:
         return self._post("getDnsRecords", {"domain": domain})
 
     def create_dns_record(self, domain: str, record: DnsRecord) -> JsonDict:
-        return self._post("dnsrecords/create", {"domain": domain, **dict(record)})
+        payload = dict(record)
+        if payload.get("type") == "TXT" and "value" not in payload and "destination" in payload:
+            payload["value"] = payload.pop("destination")
+        return self._post("dnsrecords/create", {"domain": domain, **payload})
 
     def edit_dns_record(self, domain: str, current: JsonDict, new: JsonDict) -> JsonDict:
         return self._post("dnsrecords/edit", {"domain": domain, "current": current, "new": new})

--- a/src/pycdmon/types.py
+++ b/src/pycdmon/types.py
@@ -36,6 +36,7 @@ class DnsRecord(TypedDict, total=False):
     type: str
     ttl: int
     destination: str
+    value: str
     priority: int
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,3 +74,32 @@ def test_cli_dns_create(monkeypatch, capsys) -> None:
     payload = json.loads(out)
     assert payload["data"]["record"]["host"] == "@"
     assert payload["data"]["record"]["ttl"] == 600
+    assert payload["data"]["record"]["destination"] == "1.2.3.4"
+
+
+def test_cli_dns_create_txt_uses_value(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("CDMON_API_KEY", "k")
+    monkeypatch.setattr(cli, "CdmonDomainsClient", FakeClient)
+
+    code = cli.main(
+        [
+            "dns-create",
+            "example.com",
+            "--host",
+            "@",
+            "--type",
+            "TXT",
+            "--destination",
+            "probe-openclaw",
+            "--ttl",
+            "600",
+        ]
+    )
+
+    assert code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["data"]["record"]["host"] == "@"
+    assert payload["data"]["record"]["ttl"] == 600
+    assert payload["data"]["record"]["value"] == "probe-openclaw"
+    assert "destination" not in payload["data"]["record"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,3 +68,28 @@ def test_http_error_raises_api_error() -> None:
 
     assert exc.value.status_code == 403
     assert "forbidden" in exc.value.message
+
+
+def test_create_txt_record_uses_value_field() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/dnsrecords/create"):
+            payload = request.read().decode()
+            assert '"type":"TXT"' in payload
+            assert '"value":"probe-openclaw"' in payload
+            assert '"destination"' not in payload
+            return httpx.Response(200, json={"status": "ok", "data": "Record added successfully"})
+        return httpx.Response(200, json={"status": "ok", "data": {"msg": "ok"}})
+
+    client = httpx.Client(
+        base_url="https://api-domains.cdmon.services/api-domains/",
+        headers={"apikey": "x", "Accept": "application/json", "Content-Type": "application/json"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    sdk = CdmonDomainsClient(api_key="x", client=client)
+    response = sdk.create_dns_record(
+        "example.com",
+        {"host": "@", "type": "TXT", "ttl": 900, "destination": "probe-openclaw"},
+    )
+
+    assert response["status"] == "ok"


### PR DESCRIPTION
## Summary
- map TXT DNS record creation to the `value` field instead of `destination`
- keep backward compatibility by translating `destination` to `value` for TXT in the client
- update CLI and tests to cover TXT behavior

## Validation
- ruff check .
- pytest -q
- manual real API validation against cdmon: TXT create/delete succeeds with `value` and fails with `destination`